### PR TITLE
add redirect to the events site

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -20,8 +20,7 @@ server {
     server_name _;
 
     # Redirects
-    rewrite ^/apps(.*) https://docs.ubuntu.com/phone/en/apps/index permanent;
-    rewrite ^/scopes(.*) https://docs.ubuntu.com/phone/en/scopes/index permanent;
+    rewrite ^.* https://events.canonical.com/e/summit2022 redirect;
 
     # Remove index or index.html from URIs
     if ($request_uri ~ ^.*/index(.html)?$) {


### PR DESCRIPTION
## Done

- added a redirect to the events site at https://events.canonical.com/e/summit2022

## QA

- visit https://summit-ubuntu-com-12.demos.haus/. You should be redirected to https://events.canonical.com/e/summit2022

## Issue / Card

Fixes https://github.com/canonical/web-squad/issues/5927
