### PR TITLE
Update event redirect

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -20,7 +20,7 @@ server {
     server_name _;
 
     # Redirects
-    rewrite ^.* https://events.canonical.com/e/summit2022 redirect;
+    rewrite ^.* https://events.canonical.com/event/31 redirect;
 
     # Remove index or index.html from URIs
     if ($request_uri ~ ^.*/index(.html)?$) {


### PR DESCRIPTION
## Done

- Updated redirect to point it `events.canonical.com/event/31/` instead of `events.canonical.com/event/2/`

## QA

- Open [the demo](https://summit-ubuntu-com-22.demos.haus/) and see that you are routed to the correct page

## Issue / Card

FIxes https://warthogs.atlassian.net/browse/WD-4135